### PR TITLE
Desktop notifications

### DIFF
--- a/app/views/app_notifications/_layouts_base_html_head.html.erb
+++ b/app/views/app_notifications/_layouts_base_html_head.html.erb
@@ -4,6 +4,17 @@
     <% unless Setting.plugin_redmine_app_notifications['faye_server_adress'].empty? %>
     	<%= javascript_include_tag "#{Setting.plugin_redmine_app_notifications['faye_server_adress']}/faye.js" %>
 	    <script>
+			function showNotification(data)
+			{
+				var notification = new Notification("Redmine", { "tag": "notification-"+data.id, "body": data.message });
+				notification.onclick = function(x) {
+					window.focus();
+					var issueId = this.body.match(/#(\d+)/)[1];
+					this.close();
+					location.href = "<%= url_for(:controller => 'issues', :action => 'show', :id => 0) %>"+issueId;
+				 };
+			}
+
 		    $(document).ready(function()
 				{
 			    var client = new Faye.Client("<%= Setting.plugin_redmine_app_notifications['faye_server_adress'] %>");
@@ -12,10 +23,27 @@
 						$("#notificationsLink").parent().after("<li><span id='notification_count'></span></li>");
 					}
 					$("#notification_count").text(data.count);
-				  $(document.body).append("<div class='push-notification hide' id='notification-" + data.id + "'>" + data.message + "</div>");
-			    $("#notification-" + data.id).fadeIn('fast').delay(10000).fadeOut(1200, function() {
-			    	$("#notification-" + data.id).remove();
-			    });
+					var useDesktopNotifications = false;
+					<% if User.current.app_notification_desktop %>
+					useDesktopNotifications = true;
+					<% end %>
+
+					if (!("Notification" in window) || !useDesktopNotifications) {
+					    $(document.body).append("<div class='push-notification hide' id='notification-" + data.id + "'>" + data.message + "</div>");
+					    $("#notification-" + data.id).fadeIn('fast').delay(10000).fadeOut(1200, function() {
+						$("#notification-" + data.id).remove();
+					    });
+					}
+					else {
+					    if (Notification.permission === "granted")
+							showNotification(data);
+						else if (Notification.permission !== "denied") {
+							Notification.requestPermission(function(permission) {
+								if (permission === "granted")
+									showNotification(data);
+							});
+						}
+					}
 				});
 			});
 		</script>

--- a/app/views/app_notifications/_my_account_preferences.html.erb
+++ b/app/views/app_notifications/_my_account_preferences.html.erb
@@ -1,5 +1,6 @@
 <%= labelled_fields_for :user, @user do |user_fields| %>
 	<p><%= user_fields.check_box :app_notification %></p>
+	<p><%= user_fields.check_box :app_notification_desktop %></p>
 <% end %>
 
  

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 # English strings go here for Rails i18n
 en:
   field_app_notification: "In app notifications"
+  field_app_notification_desktop: "Use desktop notifications if my browser supports it"
   notifications: "Notifications"
   see_all: "See All"
   notifications_events_settings: "In app notifications events settings"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,7 @@
 # French strings go here for Rails i18n
 fr:
   field_app_notification: "Notifications intégrées"
+  field_app_notification_desktop: "Utiliser les notifications de bureau si mon navigateur les supporte"
   notifications: "Notifications"
   see_all: "Tout voir"
   notifications_events_settings: "Paramétrage des notifications intégrées"

--- a/db/migrate/003_update_users2.rb
+++ b/db/migrate/003_update_users2.rb
@@ -1,0 +1,13 @@
+class UpdateUsers2 < ActiveRecord::Migration
+    def self.up
+        change_table :users do |t|
+            t.column :app_notification_desktop, :boolean, :default => 0
+        end
+    end
+
+    def self.down
+        change_table :users do |t|
+            t.remove :app_notification_desktop
+        end
+    end
+end

--- a/lib/app_notifications_account_patch.rb
+++ b/lib/app_notifications_account_patch.rb
@@ -14,7 +14,7 @@ module AppNotificationsAccountPatch
   module InstanceMethods
     def account_with_in_app_option
       account = account_without_in_app_option
-      User.safe_attributes 'app_notification'
+      User.safe_attributes 'app_notification', 'app_notification_desktop'
       return account
     end
   end


### PR DESCRIPTION
I think it is cool to have the possibility to use desktop notification (HTML5) if your browser supports it.

So I add an option to your plugin to "enable desktop notifications if my browser supports it".

This way, a user can have desktop notifications when he uses a compatible browser and it falls back to your original notifications if his browser does not support it.

If you click on the desktop notification, the tab with your redmine is focused and the relative issue is opened.

Hope it will interests you :)