### PR TITLE
Unreachable Faye server does not create JavaScript error (fix #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ App notifications plugin provides simple in application notifications for Redmin
 3. Optional if you want to use Faye for server to client notifications
   1. Install the Thin server `gem install thin` or configure faye.ru accordingly to the server you use. See https://github.com/faye/faye-websocket-ruby#running-your-socket-application for more details.
   2. Start the Faye server `rackup faye.ru -E production -s thin` or modify this to the server you want to use.
-  3. If you choose to use another url than http://localhost:9292/faye do not forget to change the configuration accordingly (Administration > Plugins > Configure)
+  3. In Administration > Plugins > Configure, modify `ip_address_or_name_of_your_server` to match your server IP address or name
 4. Restart your Redmine web server
 5. Login and configure the plugin (Administration > Plugins > Configure)
 6. Enable In App Notifications in user account settings -> preferences

--- a/app/views/app_notifications/_layouts_base_html_head.html.erb
+++ b/app/views/app_notifications/_layouts_base_html_head.html.erb
@@ -17,7 +17,13 @@
 
 		    $(document).ready(function()
 				{
-			    var client = new Faye.Client("<%= Setting.plugin_redmine_app_notifications['faye_server_adress'] %>");
+					try {
+						var client = new Faye.Client("<%= Setting.plugin_redmine_app_notifications['faye_server_adress'] %>");
+					} catch(e) {
+						$("#notificationsLink").parent().after("<li><span class=\"notification-title\">(<%= l(:unreachable_faye_server) %>)</span></li>");
+						return true;
+					}
+
 					var private_subscription = client.subscribe('/notifications/private/<%= User.current.id %>', function(data) {
 					if($("#notification_count").length == 0) {
 						$("#notificationsLink").parent().after("<li><span id='notification_count'></span></li>");

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,3 +18,4 @@ en:
   new_notification: "new notifications"
   filter_button: "Filter"
   view_app_notifications: "View notifications"
+  unreachable_faye_server: "Your Faye server is unreachable"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -18,3 +18,4 @@ fr:
   new_notification: "Notifications nouvelles"
   filter_button: "Filtrer"
   view_app_notifications: "Voir les notifications"
+  unreachable_faye_server: "Votre server Faye est inaccessible"

--- a/init.rb
+++ b/init.rb
@@ -27,7 +27,7 @@ Redmine::Plugin.register :redmine_app_notifications do
       'issue_status_updated' => 'on', 
       'issue_assigned_to_updated' => 'on', 
       'issue_priority_updated' => 'on',
-      'faye_server_adress' => 'http://localhost:9292/faye'
+      'faye_server_adress' => 'http://ip_address_or_name_of_your_server:9292/faye'
     }, :partial => 'settings/app_notifications_settings'
 end
 


### PR DESCRIPTION
When Faye server is unreachable, there is a JavaScript error which breaks some Redmine functionnalities (see #9 for example).
With this patch, if Faye server is unreachable we display a message to the user to alert him about the problem.