### PR TITLE
Start Faye at boot, real Id for desktop notifications and fix the issue of deleted issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ App notifications plugin provides simple in application notifications for Redmin
 2. Run the plugin migrations `rake redmine:plugins:migrate RAILS_ENV=production`
 3. Optional if you want to use Faye for server to client notifications
   1. Install the Thin server `gem install thin` or configure faye.ru accordingly to the server you use. See https://github.com/faye/faye-websocket-ruby#running-your-socket-application for more details.
-  2. Start the Faye server `rackup faye.ru -E production -s thin` or modify this to the server you want to use.
+  2. Copy the `faye_for_redmine` file to `/etc/init.d`
+  3. Modify `/etc/init.d/faye_for_redmine` to at least fill the right value for `IN_APP_NOTIFICATION_ROOT_PATH`
+  4. Makes the script starts at boot `cd /etc/init.d && update-rc.d faye_for_redmine defaults`
+  2. Start the Faye server `/etc/init.d/faye_for_redmine start` (you can stop it with `stop` instead of `start`).
   3. In Administration > Plugins > Configure, modify `ip_address_or_name_of_your_server` to match your server IP address or name
 4. Restart your Redmine web server
 5. Login and configure the plugin (Administration > Plugins > Configure)

--- a/app/views/app_notifications/_layouts_base_html_head.html.erb
+++ b/app/views/app_notifications/_layouts_base_html_head.html.erb
@@ -6,7 +6,7 @@
 	    <script>
 			function showNotification(data)
 			{
-				var notification = new Notification("Redmine", { "tag": "notification-"+data.id, "body": data.message });
+				var notification = new Notification("Redmine", { "tag": "notification-"+data.message.match(/#(\d+)/)[1], "body": data.message });
 				notification.onclick = function(x) {
 					window.focus();
 					var issueId = this.body.match(/#(\d+)/)[1];

--- a/app/views/app_notifications/_layouts_base_html_head.html.erb
+++ b/app/views/app_notifications/_layouts_base_html_head.html.erb
@@ -4,14 +4,19 @@
     <% unless Setting.plugin_redmine_app_notifications['faye_server_adress'].empty? %>
     	<%= javascript_include_tag "#{Setting.plugin_redmine_app_notifications['faye_server_adress']}/faye.js" %>
 	    <script>
+			function getIssueIdFromMessage(message)
+			{
+				return message.match(/#(\d+)/)[1];
+			}
+
 			function showNotification(data)
 			{
-				var notification = new Notification("Redmine", { "tag": "notification-"+data.message.match(/#(\d+)/)[1], "body": data.message });
+				var notification = new Notification("Redmine", { "tag": "notification-"+getIssueIdFromMessage(data.message), "body": data.message });
 				notification.onclick = function(x) {
 					window.focus();
-					var issueId = this.body.match(/#(\d+)/)[1];
+					var issueId = getIssueIdFromMessage(this.body);
 					this.close();
-					location.href = "<%= url_for(:controller => 'issues', :action => 'show', :id => 0) %>"+issueId;
+					location.href = "<%= url_for(:controller => 'app_notifications', :action => 'index') %>/"+data.id+"?issue_id="+issueId;
 				 };
 			}
 

--- a/app/views/issues/_issue_add.html.erb
+++ b/app/views/issues/_issue_add.html.erb
@@ -1,3 +1,4 @@
+<% unless notification.issue.nil? %>
 <%if !notification.viewed %>
 	<a class="view-notification" href="<%= url_for(:controller => 'app_notifications', :action => 'view', :id => notification.id, :issue_id => notification.issue.id) %>">
 		<%= l(:mark_as_seen) %>
@@ -8,3 +9,4 @@
 		<strong><%= l(:text_issue_added, :id => "##{notification.issue.id}", :author => h(notification.issue.author)) %></strong>
 	</a>
 </h3>
+<% end %>

--- a/app/views/issues/_issue_ajax_add.html.erb
+++ b/app/views/issues/_issue_ajax_add.html.erb
@@ -1,3 +1,4 @@
+<% unless notification.issue.nil? %>
 <a href="<%= url_for(:controller => 'app_notifications', :action => 'view', :id => notification.id, :issue_id => notification.issue.id) %>">
 	<div class="notification-container <%= 'new' if !notification.viewed %>">
 		<div class="notification-title">
@@ -6,3 +7,4 @@
 		<div class="notification-date"><%= format_time(notification.created_on) %></div>
 	</div>
 </a>
+<% end %>

--- a/app/views/issues/_issue_ajax_edit.html.erb
+++ b/app/views/issues/_issue_ajax_edit.html.erb
@@ -1,3 +1,4 @@
+<% unless notification.issue.nil? %>
 <a href="<%= url_for(:controller => 'app_notifications', :action => 'view', :id => notification.id, :issue_id => notification.issue.id, :anchor => "change-#{notification.journal.id}") %>">
 	<div class="notification-container <%= 'new' if !notification.viewed %>">	
 		<div class="notification-title">
@@ -11,3 +12,4 @@
 		<div class="notification-date"><%= format_time(notification.created_on) %></div>
 	</div>
 </a>
+<% end %>

--- a/app/views/issues/_issue_edit.html.erb
+++ b/app/views/issues/_issue_edit.html.erb
@@ -1,3 +1,4 @@
+<% unless notification.issue.nil? %>
 <%if !notification.viewed %>
 	<a class="view-notification" href="<%= url_for(:controller => 'app_notifications', :action => 'view', :id => notification.id, :issue_id => notification.issue.id, :anchor => "change-#{notification.journal.id}") %>">
 		<%= l(:mark_as_seen) %>
@@ -20,3 +21,4 @@
 </ul>
 
 <%= textilizable(journal, :notes, :only_path => false) %>
+<% end %>

--- a/faye_for_redmine
+++ b/faye_for_redmine
@@ -1,0 +1,76 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          faye for Redmine
+# Required-Start:    $local_fs $network
+# Required-Stop:	 $local_fs $network
+# Should-Start:
+# Default-Start:     2 3 4 5
+# Default-Stop:		 0 1 6
+# Short-Description: Starts faye server for Redmine
+# Description:       Faye is a push server which is used by the Redmine's plugin
+#                    in_app_notification
+### END INIT INFO
+
+set -e
+
+#####
+# Modify the variables to fit your needs
+#####
+
+###
+# Must modify
+###
+IN_APP_NOTIFICATION_ROOT_PATH=/root/path/to/your/redmine_app_notifications
+###
+
+###
+# Probably need to modify
+###
+SUDO_USER=www-data
+###
+
+###
+# Not necessary to modify
+###
+FAYE_RU=faye.ru
+PID=thin.pid
+REDMINE_ENVIRONMENT=production
+PORT=9292
+###
+
+CMD="cd $IN_APP_NOTIFICATION_ROOT_PATH && rackup $FAYE_RU -D -P $PID -E $REDMINE_ENVIRONMENT -s thin -p $PORT -o 0.0.0.0"
+
+set -u
+
+do_start () {
+	export RAILS_ENV="$REDMINE_ENVIRONMENT"
+	run "$CMD"
+}
+
+do_stop () {
+	run "cd $IN_APP_NOTIFICATION_ROOT_PATH && echo '' >> $PID && pkill -9 -F $PID"
+}
+
+run () {
+	if [ "$(id -un)" = "$SUDO_USER" ]; then
+		eval "$1"
+	else
+		su -c "$1" - $SUDO_USER
+	fi
+}
+
+case "$1" in
+  start)
+	do_start
+	;;
+  stop)
+	do_stop
+	;;
+  restart)
+	do_stop; do_start
+	;;
+  *)
+	echo "Usage: $0 [start|stop|restart]" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
In your README.md there is a problem.

You indicates how to start the Faye server but, it does not persists after reboot, nor is daemonized.

That is why I created a init.d script to do that and add explainations to install it.

Hope it will help.