### PR TITLE
Viewed issues checkbox is unchecked by default

### DIFF
--- a/app/controllers/app_notifications_controller.rb
+++ b/app/controllers/app_notifications_controller.rb
@@ -11,7 +11,7 @@ class AppNotificationsController < ApplicationController
     end
 
     if !params.has_key?(:viewed) && !params.has_key?(:new) && !params.has_key?(:commit) 
-      @viewed = true
+      @viewed = false
       @new = true
     else
       params.has_key?(:viewed) ? @viewed = params['viewed'] : @viewed = false


### PR DESCRIPTION
By default it is useless to see viewed notifications.

A user wants to see his viewed notifications only in rare cases.