### PR TITLE
Adjusted notification container for PurpleMine

### DIFF
--- a/assets/stylesheets/app_notifications.css
+++ b/assets/stylesheets/app_notifications.css
@@ -14,6 +14,9 @@
 	display: none;
 	font-size: 12px;
 }
+.theme-Purplemine2 #notificationsContainer {
+        margin-left: 125px;
+}
 #notificationsContainer:before {
 	content: '';
 	display: block;


### PR DESCRIPTION
Purple mine is one of the most widely used themes for RedMine and the notifications container is almost not visible on it. 

This change adjusts it, so that it appears under the Notifications link on the top navigation bar.